### PR TITLE
Fix tile alignment

### DIFF
--- a/app/src/js/components/TileTableau.vue
+++ b/app/src/js/components/TileTableau.vue
@@ -263,7 +263,7 @@
 
     .tile {
         display: flex;
-        justify-content: end;
+        justify-content: flex-start;
         align-items: center;
         flex-direction: column;
         font-size: 1rem;


### PR DESCRIPTION
On mobile, seems like the tile alignment is a bit off. Can't reproduce with emulated device browser. 